### PR TITLE
Set EN language for requests from other countries

### DIFF
--- a/websearchdict/web/fetch.py
+++ b/websearchdict/web/fetch.py
@@ -7,7 +7,8 @@ session = requests.session()
 
 
 def google_search(word):
-    url = "https://www.%s/search" % (wwa.randomGoogle())
+    url = "https://www.%s/search?hl=en" % (wwa.randomGoogle())
+    # url = "https://www.%s/search" % (wwa.randomGoogle())
     # url = "https://www.google.com/search"
     print(url)
     payload = {

--- a/websearchdict/web/fetch.py
+++ b/websearchdict/web/fetch.py
@@ -8,7 +8,6 @@ session = requests.session()
 
 def google_search(word):
     url = "https://www.%s/search?hl=en" % (wwa.randomGoogle())
-    # url = "https://www.%s/search" % (wwa.randomGoogle())
     # url = "https://www.google.com/search"
     print(url)
     payload = {


### PR DESCRIPTION
If you run this script from countries with a different language, the encoding of the returned page will be broken. Because of this, the output will be incorrect. Changed the url so that the language is set directly